### PR TITLE
Add in python3.5 explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A python API built on top of Chassis
 - [ ] `setup.py`
 - [X] ~~Code Climate~~
 - [x] Use Python 3.5
+- [ ] What Features of Python 3.5 are we leveraging? Maintain in a docs dir
 - [x] Travis
 - [x] Travis Badge in `README.md`
 - [ ] Bit Deli?


### PR DESCRIPTION
## Summary
Add a `why use python 3.5` to the docs to explain why we are using it